### PR TITLE
fix: map-filtered-map-flow-and-label-inking

### DIFF
--- a/src/components/map/MapComponent.tsx
+++ b/src/components/map/MapComponent.tsx
@@ -327,11 +327,16 @@ const MapComponent: React.FC<MapComponentProps> = ({
           const labelElement = document.createElement("div");
           labelElement.className = "custom-marker area-label-marker";
           // Use clearly smaller text on mobile, larger on desktop
-          const fontSizeClass = isDesktop ? "text-3xl" : "text-base";
+          const fontSize = isDesktop ? "text-3xl" : "text-base";
           labelElement.innerHTML = `
-            <span class="text-white font-extrabold ${fontSizeClass} select-none pointer-events-none drop-shadow-lg">
-              ${district.name}
-            </span>
+             <span class="text-white font-extrabold ${fontSize} select-none pointer-events-none opacity-90"
+      style="text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;">
+      ${district.name}
+    </span>
           `;
           const [lng, lat] = xyToLngLat(district.x, district.y, mapBounds);
           const marker = new mapboxgl.Marker({

--- a/src/desktop/components/PanelManager.tsx
+++ b/src/desktop/components/PanelManager.tsx
@@ -145,12 +145,6 @@ const PanelManager: React.ForwardRefRenderFunction<
   };
   return (
     <>
-      <PanelOverlay
-        isVisible={isMenuVisible}
-        onClose={() => setIsMenuVisible(false)}
-        withBlur={isMenuVisible || currentPanel === "filter"}
-      />
-
       <MenuPanel
         isVisible={isMenuVisible}
         onClose={() => setIsMenuVisible(false)}
@@ -163,6 +157,23 @@ const PanelManager: React.ForwardRefRenderFunction<
           setIsMenuVisible(false);
         }}
       />
+
+      {isMenuVisible && (
+        <PanelOverlay
+          isVisible={isMenuVisible}
+          onClose={() => setIsMenuVisible(false)}
+          withBlur={isMenuVisible}
+        />
+      )}
+
+      {/* Only show overlay for filter when filter is open */}
+      {currentPanel === "filter" && (
+        <PanelOverlay
+          isVisible={true}
+          onClose={handleClosePanel}
+          withBlur={true}
+        />
+      )}
 
       <DishDetailsPanel
         isVisible={currentPanel === "dishDetails"}
@@ -218,7 +229,10 @@ const PanelManager: React.ForwardRefRenderFunction<
         location={selectedLocation}
         locationKey={selectedLocationKey}
         isVisible={currentPanel === "locationDetail"}
-        onClose={handleClosePanel}
+        onClose={() => {
+          setSelectedLocation(null);
+          setCurrentPanel("filter");
+        }}
         onViewDetails={() => {
           setCurrentPanel("locationDetail");
         }}

--- a/src/mobile/components/PanelManager.tsx
+++ b/src/mobile/components/PanelManager.tsx
@@ -95,20 +95,25 @@ const PanelManager: React.ForwardRefRenderFunction<
     setCurrentPanel("home");
   }, []);
 
-  const isModalVisible =
-    isMenuVisible ||
-    (currentPanel !== null && ["menu", "filter"].includes(currentPanel));
-
   return (
     <>
       {isMenuVisible && (
         <PanelOverlay
-          isVisible={isModalVisible}
+          isVisible={isMenuVisible}
           onClose={() => {
             setCurrentPanel(null);
             setIsMenuVisible(false);
           }}
-          withBlur={isMenuVisible || currentPanel === "filter"}
+          withBlur={isMenuVisible}
+        />
+      )}
+
+      {/* Only show overlay for filter when filter is open */}
+      {currentPanel === "filter" && (
+        <PanelOverlay
+          isVisible={true}
+          onClose={() => setCurrentPanel(null)}
+          withBlur={true}
         />
       )}
 
@@ -159,7 +164,7 @@ const PanelManager: React.ForwardRefRenderFunction<
         isVisible={currentPanel === "locationSummary"}
         onClose={() => {
           setSelectedLocation(null);
-          setCurrentPanel(null);
+          setCurrentPanel("filter");
         }}
         onViewDetails={() => {
           setCurrentPanel("locationDetail");


### PR DESCRIPTION
This PR includes:

1.) Map flow after filter is closed
2.) Black outline on mobile and desktop view on district labels

<img width="2260" height="1249" alt="image" src="https://github.com/user-attachments/assets/ee09d999-525f-4e7e-ae77-e57f3ab8e14c" />
